### PR TITLE
Adds missing news fragments for all previous PRs

### DIFF
--- a/changes/100.bugfix.md
+++ b/changes/100.bugfix.md
@@ -1,0 +1,3 @@
+Threshold cross-over between resonance approximation and mixing was off-by-one.
+1. Treats particles that are not in the standard_particle list as resonances.
+2. Fixes condition for finding the mixing energy from `threshold>cross_over` to `threshold>=cross_over`.

--- a/changes/106.bugfix.md
+++ b/changes/106.bugfix.md
@@ -1,0 +1,1 @@
+Fixes correctly setting the user-provided interaction model in the `init` of `MCEqRun`. Initialization failed if `SIBYLL2.3C` was not included in the database.

--- a/changes/63.chore.md
+++ b/changes/63.chore.md
@@ -1,0 +1,1 @@
+Update the MKL backend of MCEq to use more modern `oneMKL` library.

--- a/changes/64.chore.md
+++ b/changes/64.chore.md
@@ -1,0 +1,1 @@
+Cleaning up tests of MCEq.

--- a/changes/67.chore.md
+++ b/changes/67.chore.md
@@ -1,0 +1,1 @@
+Adding new tests to `MCEq.core`. Enhances test coverage!

--- a/changes/74.chore.md
+++ b/changes/74.chore.md
@@ -1,0 +1,1 @@
+Adding new tests to `MCEq.solvers`. Enhances test coverage!

--- a/changes/77.chore.md
+++ b/changes/77.chore.md
@@ -1,0 +1,1 @@
+Adding new tests to `MCEq.geometry`. Covers densities and atmospheres. Enhances test coverage!

--- a/changes/80.chore.md
+++ b/changes/80.chore.md
@@ -1,0 +1,1 @@
+Removes the `WHR_charm` class! Adds tests for `MCEq.charm_models`. Enhances test coverage!

--- a/changes/81.bugfix.md
+++ b/changes/81.bugfix.md
@@ -1,0 +1,1 @@
+Fixes `z_factor` calculation if minimal MCEq energy is above 2 GeV. Just failed before.

--- a/changes/82.docs.md
+++ b/changes/82.docs.md
@@ -1,0 +1,1 @@
+Completely updates the MCEq documentation to new `pydata_sphinx_theme`. Enjoy it on [mceq.readthedocs.io](https://mceq.readthedocs.io)!

--- a/changes/83.bugfix.md
+++ b/changes/83.bugfix.md
@@ -1,0 +1,4 @@
+Fixes/Updates backends for MCEq:
+1. CUDA: Update from `cupy.cusparse.csrmv` to newer `cupyx.scipy.sparse`
+2. Numpy: Fixed bug where numpy solver mutates the input arrays, resulting in wrong solutions for subsequent calls of `MCEqRun.solve()`
+3. MKL: Fixed error due do not being able to find MKL library

--- a/changes/91.docs.md
+++ b/changes/91.docs.md
@@ -1,0 +1,1 @@
+Adds `intersphinx` mappings to the Documentation. Enables cross-referencing to other external documentations.

--- a/changes/93.docs.md
+++ b/changes/93.docs.md
@@ -1,0 +1,1 @@
+Fixes the ReadTheDocs build by changing the install method of the `docs` dependencies in `.readthedocs.yml`.


### PR DESCRIPTION
This PR adds all newsfragments for all previous PRs after we accept towncrier as the new changelog tool.