### PR TITLE
Prepare MCEq 1.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 <!-- towncrier release notes start -->
 
+# MCEq 1.4.1 (2026-03-16)
+
+## Bug Fixes
+
+- Fixed segfault at interpreter exit on macOS when the Accelerate (spacc) solver is used. The `atexit` handler and `SpaccMatrix.__del__` both tried to free the same sparse matrix handles, causing a double-free via `sparse_matrix_destroy(NULL)`. Removed the redundant `atexit` handler (cleanup is handled solely by `__del__`) and added a NULL guard in the C-level `free_mstore_at` as defence-in-depth.
+
+  Bump version to 1.4.1 for a new bugfix release. ([#150](https://github.com/mceq-project/MCEq/pull/150))
+- Fixed an ordering bug in tests that could result in uncontrolled model settings in integration_path tests when executed with `pytest-xdist`. ([#151](https://github.com/mceq-project/MCEq/pull/151))
+
+## Maintencance
+
+- Defer the MCEq database download from import time to the first ``MCEqRun``
+  instantiation via ``config.ensure_db_available()``. This prevents the large
+  default database from being downloaded when ``MCEq.config`` is merely imported
+  (e.g. during test collection). CI workflow now uses the ``cache-hit`` output of
+  ``actions/cache`` to reliably skip redundant downloads. ([#147](https://github.com/mceq-project/MCEq/pull/147))
+
+
 # MCEq 1.4.0 (2026-03-04)
 
 ## Bug Fixes

--- a/changes/147.chore.md
+++ b/changes/147.chore.md
@@ -1,5 +1,0 @@
-Defer the MCEq database download from import time to the first ``MCEqRun``
-instantiation via ``config.ensure_db_available()``. This prevents the large
-default database from being downloaded when ``MCEq.config`` is merely imported
-(e.g. during test collection). CI workflow now uses the ``cache-hit`` output of
-``actions/cache`` to reliably skip redundant downloads.

--- a/changes/150.bugfix.md
+++ b/changes/150.bugfix.md
@@ -1,3 +1,0 @@
-Fixed segfault at interpreter exit on macOS when the Accelerate (spacc) solver is used. The `atexit` handler and `SpaccMatrix.__del__` both tried to free the same sparse matrix handles, causing a double-free via `sparse_matrix_destroy(NULL)`. Removed the redundant `atexit` handler (cleanup is handled solely by `__del__`) and added a NULL guard in the C-level `free_mstore_at` as defence-in-depth.
-
-Bump version to 1.4.1 for a new bugfix release.

--- a/src/MCEq/core.py
+++ b/src/MCEq/core.py
@@ -109,6 +109,7 @@ class MCEqRun:
 
         # Set atmosphere and geometry
         self.integration_path, self.int_grid, self.grid_var = None, None, None
+        self._cached_leading_process = None
         self.set_density_model(self.density_model)
 
         # Set initial flux condition
@@ -1114,11 +1115,13 @@ class MCEqRun:
             self.integration_path
             and np.all(int_grid == self.int_grid)
             and np.all(self.grid_var == grid_var)
+            and self._cached_leading_process == config.leading_process
             and not force
         ):
             info(5, "skipping calculation.")
             return
 
+        self._cached_leading_process = config.leading_process
         self.int_grid, self.grid_var = int_grid, grid_var
         if grid_var != "X":
             raise NotImplementedError(

--- a/src/MCEq/geometry/corsikaatm/__init__.py
+++ b/src/MCEq/geometry/corsikaatm/__init__.py
@@ -11,7 +11,7 @@ if suffix is None and "SO" in sysconfig.get_config_vars():
 assert suffix is not None, "Shared lib suffix was not identified."
 
 for fn in os.listdir(base):
-    if "libcorsikaatm" in fn and fn.endswith(suffix):
+    if fn.startswith("_libcorsikaatm") and fn.endswith(suffix):
         corsika_acc = cdll.LoadLibrary(os.path.join(base, fn))
         break
 

--- a/src/MCEq/geometry/nrlmsise00/__init__.py
+++ b/src/MCEq/geometry/nrlmsise00/__init__.py
@@ -16,7 +16,7 @@ if suffix is None and "SO" in sysconfig.get_config_vars():
 assert suffix is not None, "Shared lib suffix was not identified."
 
 for fn in os.listdir(base):
-    if "libnrlmsis" in fn and fn.endswith(suffix):
+    if fn.startswith("_libnrlmsis") and fn.endswith(suffix):
         msis = cdll.LoadLibrary(os.path.join(base, fn))
         break
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -51,7 +51,7 @@ def test_solve_int_grid(mceq_sib21, int_grid, grid_shape):
     [
         ["decays", 1248],
         ["auto", 1248],
-        ["interactions", 1248],
+        ["interactions", 1034],
     ],
 )
 def test_integration_path_leading_process(mceq_sib21, leading_process, lenX):


### PR DESCRIPTION
## Summary

- Fix integration path cache not invalidating when `config.leading_process` changes by tracking `_cached_leading_process` in `MCEqRun` (#151)
- Fix shared library loading in `corsikaatm` and `nrlmsise00` to use `startswith("_lib...")` to avoid accidentally matching unrelated files
- Update test expectation for `interactions` leading process integration path length (1248 → 1034)
- Consolidate `changes/147.chore.md` and `changes/150.bugfix.md` fragments into `CHANGELOG.md` for the 1.4.1 release

## Test plan

- [ ] Run `pytest tests/test_core.py` to verify `test_integration_path_leading_process` passes with the corrected expected length
- [ ] Verify geometry extension modules load correctly on macOS/Linux with the updated library name matching
- [ ] Confirm changelog renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)